### PR TITLE
updating the run_tests to use pythons tempfile for auto cleanup as we…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ In the command above, the `-it` flag starts the container in interactive mode, s
 To test the installation, run the following command from the odm directory:
 
 ```bash
+./run_tests.py
+```
+
+if you are on Windows, run the following command from the odm directory:
+
+```bash
 python run_tests.py
 ```
 

--- a/odm/run_tests.py
+++ b/odm/run_tests.py
@@ -1,55 +1,70 @@
+#!/usr/bin/env python3
 import configparser
 import os
 import shutil
 import subprocess
+import tempfile
 
 
 def run_tests():
     # Define the repository and the local directory to clone it into
     repo = "https://github.com/RyanZurrin/ODM_TEST_DATA.git"
-    local_dir = "/tmp/ODM_TEST_DATA"
 
     # Backup the current __configloc__.py file
     shutil.copyfile("core/__configloc__.py", "__configloc__.py.bak")
 
-    try:
-        # Clone the repository
-        subprocess.check_call(["git", "clone", repo, local_dir])
+    with tempfile.TemporaryDirectory() as local_dir:
+        try:
+            return _run_test_driver(repo, local_dir)
+        except subprocess.CalledProcessError as e:
+            print(f"Tests failed with error code {e.returncode}")
+            return False
+        finally:
+            # Restore the original __configloc__.py file
+            shutil.copyfile("__configloc__.py.bak", "core/__configloc__.py")
 
-        # Read the configuration file
-        config = configparser.ConfigParser()
-        config.read("config/test_config.ini")
+            if os.path.isdir('/tmp/odm_test/'):
+                shutil.rmtree('/tmp/odm_test/')
 
-        # Update the data_root in the configuration file
-        config["5BHIST"]["data_root"] = os.path.join(local_dir, "TEST_DATA")
+            # delete the backup __configloc__.py file
+            os.remove("__configloc__.py.bak")
 
-        # Write the updated configuration to a new file
-        updated_config_path = "config/test_config.ini"
-        with open(updated_config_path, "w") as configfile:
-            config.write(configfile)
 
-        # Update the __configloc__.py file
-        with open("core/__configloc__.py", "w") as f:
-            f.write(f'CONFIG_LOC = "{updated_config_path}"')
+def _run_test_driver(repo, local_dir):
+    """
+    """
+    subprocess.check_call(["git", "clone", repo, local_dir])
 
-        # Run the config
-        subprocess.check_call(["python", "run_pipeline.py"])
-        print("Tests completed successfully")
+    # Read the configuration file
+    config = configparser.ConfigParser()
+    config.read("config/test_config.ini")
+
+    # Update the data_root in the configuration file
+    config["5BHIST"]["data_root"] = os.path.join(local_dir, "TEST_DATA")
+
+    # Write the updated configuration to a new file
+    updated_config_path = "config/test_config.ini"
+    with open(updated_config_path, "w") as configfile:
+        config.write(configfile)
+
+    # Update the __configloc__.py file
+    with open("core/__configloc__.py", "w") as f:
+        f.write(f'CONFIG_LOC = "{updated_config_path}"')
+
+    # Run the config
+    subprocess.check_call(["python", "run_pipeline.py"])
+
+    # Count the number of images
+    with open('/tmp/odm_test/logs/good_paths.txt', 'r') as f:
+        good_images_count = sum(1 for _ in f)
+
+    if good_images_count == 81:
+        print("Tests completed successfully!")
         return True
-
-    except subprocess.CalledProcessError as e:
-        print("Tests failed with error code", e.returncode)
+    else:
+        print(f"Expected 81 images, but found {good_images_count}")
         return False
 
-    finally:
-        # Restore the original __configloc__.py file
-        shutil.copyfile("__configloc__.py.bak", "core/__configloc__.py")
-
-        # Delete the cloned repository
-        shutil.rmtree(local_dir)
-
-        # delete the backup __configloc__.py file
-        os.remove("__configloc__.py.bak")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ll as have added additional checks to verify the correct number of goodimages was found in addition to it running correclty. Also added the ability for unix and mac systems to omit having to call python in front of the run_tests allowing it to be ran like a normal bash script.