### PR TITLE
BUG FIX: Update vae_runner.py to support non-DICOM images

### DIFF
--- a/odmammogram/core/vae_runner.py
+++ b/odmammogram/core/vae_runner.py
@@ -52,7 +52,7 @@ def load_data_batch(files, timing):
     data_dict = {}
     for index, file in tqdm(enumerate(files), desc="Loading files", total=len(files)):
         try:
-            if file.endswith(".dcm") or file.endswith(".DCM") or file.endswith(""):
+            if file.endswith(".dcm") or file.endswith(".DCM"):
                 data_dict[index] = [dicom.dcmread(file).pixel_array, file]  # DICOM
             elif file.endswith(tuple(img_formats)):
                 with Image.open(file) as img:


### PR DESCRIPTION
all files  end with empty string, so it would always assumes it is loading a DICOM file